### PR TITLE
Direct lookup based on from + to fields

### DIFF
--- a/cors.pl
+++ b/cors.pl
@@ -1,8 +1,10 @@
 #!/usr/bin/perl -w
 
-# circumventing CORS by relaying a http request
-# usage :  cors.pl?url=baseurl&param1=val1&param2=val2
-# expecting json format output
+# Circumventing CORS by relaying a http request
+# Expecting json format output
+# Usage :  cors.pl?url=baseurl&param1=val1&param2=val2
+#          verify_SSL=0  - will disable certificate checking (and reduce level of security)
+#   
 
 use strict;
 use CGI qw/:standard -debug/;
@@ -24,7 +26,7 @@ my $key;
 # copy parameters
 my $params;
 foreach $key ($cgi->param){
-    if ( $key ne "url" && $key ne 'method'){ 
+    if ( $key ne "url" && $key ne 'method' && $key ne 'verify_SSL'){ 
 	if ( $params){
 	    $params .= '&';
 	} else {
@@ -36,8 +38,14 @@ foreach $key ($cgi->param){
 }
 my $url;
 if ( $url=$cgi->param( "url" ) ) {
-    
-    my $response = HTTP::Tiny->new->get( $url . $params);
+
+    my $http_session;
+    if (defined $cgi->param("verify_SSL")) {
+	$http_session = HTTP::Tiny->new( ('verify_SSL' =>  $cgi->param("verify_SSL")) );
+    } else {
+	$http_session = HTTP::Tiny->new();
+    }	
+    my $response = $http_session->get( $url . $params);
     # if ($response->{success}) {
 	print  $cgi->header( -type => $response->{headers}{'content-type'},  -charset => 'utf-8');
 	print $response->{content};

--- a/ls.html
+++ b/ls.html
@@ -143,6 +143,13 @@ function fetch_base(url, start_time){
 			    head+=tr;
 			    //$('#peer_table tr:last').after( tr);
 			    pairs[pair] = true;
+
+			    if (urlParams["from"] == event["input-source"] && urlParams["to"] == event["input-destination"] ) {
+				// A pair of measurement nodes are already specified. Display tracetree.
+				tracetree(server, mno);
+				$('#page-title').hide();
+				return;
+			    }
 			}
 		    }
 		});
@@ -172,6 +179,9 @@ function tracetree( srv, mno){
     var url='tracetree.html?mahost=' + base;
     url+="&from=" + tr_events[mno]["input-source"];
     url+="&to=" + tr_events[mno]["input-destination"];
+    if ( urlParams["stime"] ) {
+	url+="&stime=" + urlParams["stime"];
+    }
     //url = 'cors.pl?method=GET&url=' + encodeURI(url);
 
     console.log( 'ls::tracetree ' + url );
@@ -304,7 +314,7 @@ function search_table(input,table) {
 
 </head>
 <body>
-  <h2>World Perfsonar Measurement Archives</h2>
+  <h2 id=page-title>World Perfsonar Measurement Archives</h2>
   <div id=tabs>
   
     <ul>

--- a/ls.html
+++ b/ls.html
@@ -148,7 +148,6 @@ function fetch_base(url, start_time){
 				// A pair of measurement nodes are already specified. Display tracetree.
 				tracetree(server, mno);
 				$('#page-title').hide();
-				return;
 			    }
 			}
 		    }

--- a/ls.html
+++ b/ls.html
@@ -60,7 +60,13 @@ function fetch_ma(loc, start_time){
     head+='<table id="ma_table" class=sortable border=1><thead title="Sortable"><tr><th>Service<th>Location<th>Country<th>URls</thead><tbody>';
     var tail='</tbody></table>';
     // var cors='cors.pl?method=GET&url=' + encodeURI(url);
-    var cors='cors.pl?method=GET&url=' + url;
+
+    var verify_SSL="";
+    if ('verify_SSL' in urlParams){
+	verify_SSL = "verify_SSL=" + urlParams['verify_SSL'] + "&";
+    }
+
+    var cors='cors.pl?' + verify_SSL + 'method=GET&url=' + url;
 
     $.getJSON( cors, function( mas){
     // $.getJSON( url, function( mas){
@@ -114,7 +120,11 @@ function fetch_base(url, start_time){
     }
     
     url+='&tool-name=pscheduler/traceroute';
-    url = 'cors.pl?method=GET&url=' + url;
+    var verify_SSL="";
+    if ('verify_SSL' in urlParams){
+	verify_SSL = "verify_SSL=" + urlParams['verify_SSL'] + "&";
+    }
+    url = 'cors.pl?' + verify_SSL + 'method=GET&url=' + url;
     var msg='Fetching MA ' + url;
     console.log(msg);
     $("#peers").html(msg);
@@ -181,6 +191,10 @@ function tracetree( srv, mno){
     if ( urlParams["stime"] ) {
 	url+="&stime=" + urlParams["stime"];
     }
+    if ('verify_SSL' in urlParams){
+	url = url + "&verify_SSL=" + urlParams['verify_SSL'];
+    }
+
     //url = 'cors.pl?method=GET&url=' + encodeURI(url);
 
     console.log( 'ls::tracetree ' + url );

--- a/tracetree.js
+++ b/tracetree.js
@@ -479,7 +479,11 @@ function fetch_and_plot_json(slice, base) {
     //}
 
     var url = 'cors.pl?method=GET&url=' + encodeURI(tpath);
+    if ('verify_SSL' in urlParams){
+	url = url + "&verify_SSL=" + urlParams['verify_SSL'];
+    }
     console.log('traceroute path:' + url );
+
     
     var jqxhr = $.getJSON( url, function( tr_json){
 	//	  plot_tree_json(reduce_graph(data));


### PR DESCRIPTION
Added code to enable direct display of traceroutes from a specific archive and a specific pair of measurement hosts. ls.html now forwards "from" and "to" parameters to tracetree.html .

... and a cors.pl (as wel as ls.html and tracetree.html) is enhanced to handle homebrewed ssl certificates by enabling "verify_SSL" to be toggled. 